### PR TITLE
Bsd license fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "keywords": [ "bnf", "parser", "grammar", "ast" ],
   "author": "Daniel Connelly <dhconnelly@gmail.com> (http://dhconnelly.com)",
-  "license": "BSD",
+  "license": "BSD-2-Clause",
   "readmeFilename": "README.md",
   "devDependencies": {
     "nodeunit": "0.7.x",


### PR DESCRIPTION
npm complains about invalid license format.  I compared with this list:

https://spdx.org/licenses/

and figured from your LICENSE that it was a BSD 2 clause simplified.  The npm warning goes away after that.